### PR TITLE
解决问题：1.ajax页面请求后，前面同ID的页面仍存在页面,解决后，在将请求到的页面插入前，会移除页面已有的同ID页面 *  * 2.工具栏切换不入栈(已解决)

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -148,11 +148,13 @@
        */      
        var newPageId=$(page).attr("id");
        $("#"+newPageId).remove();
+	   if($(".page")[0])
+      page.insertAfter($(".page")[0]);
+  else
+	   page.appendTo($("body")[0]);
        /**
         *  end added 
         */
-      page.insertAfter($(".page")[0]);
-
       var id = this.genStateID();
       this.setCurrentStateID(id);
 


### PR DESCRIPTION
 * modified by xiaohelong 20151211
 * 修改目标：
 * 1.ajax页面请求后，前面同ID的页面仍存在页面,解决后，在将请求到的页面插入前，会移除页面已有的同ID页面 *
 * 2.工具栏切换不入栈(已解决)
 * 原文如下："注意如果你希望点击工具栏切换页面，一定要用内联页面进行切换，不然会造成重复加载的问题，具体用法参见 light7商城。"
 * =====================================================
 * 使用方式
 * 在a链接元素中，添加toolbar-tab属性或者类
 * 解决办法：
 * 原理描述：在加载页面开始处，检测具有toolbar-tab属性或类的a元素单击事件，如果是将不送入队列.
 * 2.1 在  Router.prototype.loadPage = function(url, noAnimation)的基础上，添加函数
      Router.prototype.loadPage = function(url, noAnimation,$target);
   2.2并将调用改成新增函数的调用。
      原函数调用 router.loadPage(url, $target.hasClass("no-transition"));
     更改后 router.loadPage(url, $target.hasClass("no-transition"),$target);
 */